### PR TITLE
meson: add WITH_NETPLAN to config.h.meson

### DIFF
--- a/config.h.meson
+++ b/config.h.meson
@@ -271,3 +271,5 @@
 /* Define to 1 if you have history support from -lreadline. */
 #mesondefine HAVE_READLINE_HISTORY
 
+/* Define to 1 to enable integration with Netplan */
+#mesondefine WITH_NETPLAN


### PR DESCRIPTION
It's required in order to populate the config.h file with the WITH_NETPLAN definition.

In other words, building with meson wasn't really working.